### PR TITLE
Fix url func import for Django 3.1+

### DIFF
--- a/wagtail_purge/admin_urls.py
+++ b/wagtail_purge/admin_urls.py
@@ -1,4 +1,9 @@
-from django.conf.urls import url
+import django
 from .views import purge
 
-urlpatterns = [url(r"^$", purge, name="purge")]
+if django.VERSION >= (3, 1):
+    from django.urls import re_path
+else:
+    from django.conf.urls import url as re_path
+
+urlpatterns = [re_path(r"^$", purge, name="purge")]


### PR DESCRIPTION
`django.conf.urls.url` is deprecated as of Django 3.1 and has been removed in Django 4.0.

See also: https://docs.djangoproject.com/en/3.2/releases/3.1/#id2

The import that is used is now dependent on the Django version used.