### PR TITLE
Support Wagtail 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+
+ - Add support for Wagtail 3.0 and drop support for all Wagtail versions
+   before 2.15
+   
+ - Add support for Django 4.0 and drop support for all Django versions
+   before 3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Add support for Wagtail 3.0 and drop support for all Wagtail versions
    before 2.15
    
- - Add support for Django 4.0 and drop support for all Django versions
-   before 3.0
+ - Drop support for all Django versions before 3.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
         "Environment :: Web Environment",
         "Framework :: Django",
         "Framework :: Django :: 3.2",
-        "Framework :: Django :: 4.0",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 2",
         "Framework :: Wagtail :: 3",

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,11 @@ setup(
     classifiers=[
         "Environment :: Web Environment",
         "Framework :: Django",
+        "Framework :: Django :: 3.2",
+        "Framework :: Django :: 4.0",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 2",
+        "Framework :: Wagtail :: 3",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
@@ -29,6 +32,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "wagtail>=2",
+        "wagtail>=2.15",
+        "django>=3.0,<4.0"
     ],
 )

--- a/wagtail_purge/wagtail_hooks.py
+++ b/wagtail_purge/wagtail_hooks.py
@@ -1,4 +1,8 @@
-from wagtail.core import hooks
+try:
+    from wagtail import hooks
+except ImportError:
+    # Wagtail<3.0
+    from wagtail.core import hooks
 from wagtail.admin.menu import AdminOnlyMenuItem
 from django.urls import include, reverse, path
 from . import admin_urls


### PR DESCRIPTION
[Ticket
](https://projects.torchbox.com/projects/support-team/tickets/494)

Make the current package support Wagtail 3.0. 

- Drop Django 2.2 (EOL)
- Drop Python 3.6 (EOL)
- Drop Wagtail <2.15 (EOL)
- Add Wagtail 3.0 support
