### PR TITLE
Allow Wagtail 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Add support for Wagtail 4 and drop django versions before 3.2 and allow django 4.1
+
 ## 0.2.0
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,6 @@ setup(
     zip_safe=False,
     install_requires=[
         "wagtail>=2.15",
-        "django>=3.0,<4.0"
+        "django>=3.2,<4.2",
     ],
 )

--- a/wagtail_purge/admin_urls.py
+++ b/wagtail_purge/admin_urls.py
@@ -1,9 +1,5 @@
-import django
 from .views import purge
 
-if django.VERSION >= (3, 1):
-    from django.urls import re_path
-else:
-    from django.conf.urls import url as re_path
+from django.urls import re_path
 
 urlpatterns = [re_path(r"^$", purge, name="purge")]

--- a/wagtail_purge/wagtail_hooks.py
+++ b/wagtail_purge/wagtail_hooks.py
@@ -1,12 +1,13 @@
-try:
-    from wagtail import hooks
-except ImportError:
-    # Wagtail<3.0
-    from wagtail.core import hooks
-from wagtail.admin.menu import AdminOnlyMenuItem
 from django.urls import include, reverse, path
-from . import admin_urls
+from wagtail import VERSION as WAGTAIL_VERSION
+from wagtail.admin.menu import AdminOnlyMenuItem
 
+if WAGTAIL_VERSION >= (3, 0):
+    from wagtail import hooks
+else:
+    from wagtail.core import hooks
+    
+from . import admin_urls
 
 @hooks.register("register_admin_urls")
 def register_admin_urls():


### PR DESCRIPTION
This adjusts some Wagtail compatibility checks to be of a format that we have unofficially adopted using `if else` blocks.

- Drops support for Django < 3.2
- Allows support for Django < 4.2