### PR TITLE
Wagtail 5.1+ upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Support for Wagtail version 5.1
+- Support for Wagtail version 5.1 and 5.2
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Support for Wagtail version 5.1
+
 ## 0.3.0
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Framework :: Django",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.1",

--- a/wagtail_purge/templates/index.html
+++ b/wagtail_purge/templates/index.html
@@ -24,7 +24,9 @@
         {% csrf_token %}
         <ul class="fields">
             {% for field in form %}
-            {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+            <li>
+                {% include "wagtailadmin/shared/field.html" with field=field %}
+            </li>
             {% endfor %}
             <li><input type="submit" value="{% trans 'Submit Purge Request' %}" class="button" /></li>
         </ul>

--- a/wagtail_purge/wagtail_hooks.py
+++ b/wagtail_purge/wagtail_hooks.py
@@ -15,9 +15,9 @@ def register_admin_urls():
 @hooks.register("register_settings_menu_item")
 def register_purge_menu_item():
     if WAGTAIL_VERSION >= (5, 2):
-            kwargs = {"classname": "icon icon-collapse-down"}
-        else:
-            kwargs = {"classnames": "icon icon-collapse-down"}
+        kwargs = {"classname": "icon icon-collapse-down"}
+    else:
+        kwargs = {"classnames": "icon icon-collapse-down"}
 
     return AdminOnlyMenuItem(
         "CDN purge",

--- a/wagtail_purge/wagtail_hooks.py
+++ b/wagtail_purge/wagtail_hooks.py
@@ -17,6 +17,6 @@ def register_purge_menu_item():
     return AdminOnlyMenuItem(
         "CDN purge",
         reverse("purge"),
-        classnames="icon icon-collapse-down",
+        classname="icon icon-collapse-down",
         order=1000,
     )

--- a/wagtail_purge/wagtail_hooks.py
+++ b/wagtail_purge/wagtail_hooks.py
@@ -1,7 +1,7 @@
 from django.urls import include, reverse, path
 from wagtail.admin.menu import AdminOnlyMenuItem
 
-from wagtail import hooks
+from wagtail import hooks, VERSION as WAGTAIL_VERSION
     
 from . import admin_urls
 
@@ -14,9 +14,14 @@ def register_admin_urls():
 
 @hooks.register("register_settings_menu_item")
 def register_purge_menu_item():
+    if WAGTAIL_VERSION >= (5, 2):
+            kwargs = {"classname": "icon icon-collapse-down"}
+        else:
+            kwargs = {"classnames": "icon icon-collapse-down"}
+
     return AdminOnlyMenuItem(
         "CDN purge",
         reverse("purge"),
-        classname="icon icon-collapse-down",
         order=1000,
+        **kwargs
     )


### PR DESCRIPTION
## Wagtail 5.1 ([See release notes](https://docs.wagtail.org/en/stable/releases/5.1.html))

- [Shared include field_as_li.html will be removed](https://docs.wagtail.org/en/stable/releases/5.1.html#shared-include-field-as-li-html-will-be-removed)


## Wagtail 5.2 ([See release notes](https://docs.wagtail.org/en/stable/releases/5.2.html))

- [Adoption of classname convention for MenuItem related classes and hooks](https://docs.wagtail.org/en/stable/releases/5.2.html#adoption-of-classname-convention-for-menuitem-related-classes-and-hooks)


## Other changes

- Update changelog
- Update classifiers