### PR TITLE
Maintenance update Wagtail 6.3 & 64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated supported Wagtail versions to 5.2 and above
 - Support for Django version 5.0
+- Drop support for Django < 4.2
 
 ## 0.3.0
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(
     classifiers=[
         "Environment :: Web Environment",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -24,6 +23,7 @@ setup(
         "Framework :: Django",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
+        "Framework :: Django :: 5.1",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 5",
         "Framework :: Wagtail :: 6",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Framework :: Django",
-        "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
         "Framework :: Wagtail",

--- a/wagtail_purge/wagtail_hooks.py
+++ b/wagtail_purge/wagtail_hooks.py
@@ -18,5 +18,5 @@ def register_purge_menu_item():
         "CDN purge",
         reverse("purge"),
         order=1000,
-        classname="icon icon-collapse-down",
+        icon_name="collapse-down",
     )


### PR DESCRIPTION
# 6.4 upgrade

- Adds Python 3.13 to classifiers

# 6.3 upgrade

https://github.com/torchbox/wagtail-purge/pull/13 Is included here.

This pull request includes updates to the supported versions of Django and Wagtail, modifications to the `setup.py` file to reflect these changes, and a minor update to the `wagtail_purge` module.

Includes: https://github.com/torchbox/wagtail-purge/pull/12

### Version Support Updates:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR16): Dropped support for Django versions below 4.2.

### Setup Configuration Updates:
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L19-R26): Removed support for Python 3.8 and Django 3.2, and added support for Django 5.1.

### Codebase Simplification:
* [`wagtail_purge/wagtail_hooks.py`](diffhunk://#diff-b6f14b43052b64269941d61e8b40459f4821476be4193f594cfe967754596c45L21-R21): Changed the `classname` parameter to `icon_name` in the `register_purge_menu_item` function.