### PR TITLE
Maintenance upgrade Wagtail 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated supported Wagtail versions to 5.2 and above
 - Support for Django version 5.0
+- Drop support for Django < 4.2
 
 ## 0.3.0
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(
     classifiers=[
         "Environment :: Web Environment",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -24,6 +23,7 @@ setup(
         "Framework :: Django",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
+        "Framework :: Django :: 5.1",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 5",
         "Framework :: Wagtail :: 6",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Framework :: Django",
-        "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
         "Framework :: Wagtail",

--- a/wagtail_purge/wagtail_hooks.py
+++ b/wagtail_purge/wagtail_hooks.py
@@ -18,5 +18,5 @@ def register_purge_menu_item():
         "CDN purge",
         reverse("purge"),
         order=1000,
-        classname="icon icon-collapse-down",
+        icon_name="collapse-down",
     )


### PR DESCRIPTION
Based on #14 and #13

Drops support for deprecated versions of Wagtail and Django